### PR TITLE
Add missing header so it compiles on Arch Linux

### DIFF
--- a/src/pred/desynchronizer.hpp
+++ b/src/pred/desynchronizer.hpp
@@ -19,6 +19,7 @@
 #include <pred/predicate_parser.hpp>   // desync::predicate_parser
 #include <random>                      // std::mt19937, std::random_device, std::..._distribution
 #include <regex>                       // std::regex, std::regex_match
+#include <ranges>                      // std::views
 #include <span>                        // std::span
 #include <sstream>                     // std::ostringstream
 #include <stdexcept>                   // std::runtime_error


### PR DESCRIPTION
There was a missing header that caused it to not compile on my system. There
might be differences between configurations on different OS-s, so I added it.
This will make it easier for other people to also compile the project. :dango: 
